### PR TITLE
Updated to 1.20.6 (edit: not official)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        game_version: ["1.20.1", "1.20.2", "1.20.4"]
+        game_version: ["1.20.6"]
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Repository
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: temurin
           cache: gradle
-          java-version: 17
+          java-version: 21
       - run: chmod +x gradlew
       - name: Set Active Version
         run: ./gradlew "Set active version to ${{ matrix.game_version }}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -81,7 +81,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 17
+    it.options.release = 21
 }
 
 java {
@@ -90,8 +90,8 @@ java {
     // If you remove this line, sources will not be generated.
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ mod.target=VERSIONED
 # Dependencies
 # https://fabricmc.net/develop
 deps.yarn=VERSIONED
-deps.fabric_loader=0.15.3
+deps.fabric_loader=0.15.11
 deps.yacl_version=VERSIONED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,8 @@ plugins {
 
 stonecutter {
     shared {
-        versions '1.20.4', '1.20.2', '1.20.1'
-        vcsVersion '1.20.4'
+        versions '1.20.6'
+        vcsVersion '1.20.6'
     }
 
     create rootProject

--- a/src/main/java/com/mineblock11/foglooksgoodnow/FogManager.java
+++ b/src/main/java/com/mineblock11/foglooksgoodnow/FogManager.java
@@ -208,14 +208,16 @@ public class FogManager {
                 darknessValue = 1.0F;
             } else if (e.hasStatusEffect(StatusEffects.DARKNESS)) {
                 StatusEffectInstance effect = e.getStatusEffect(StatusEffects.DARKNESS);
-                if (!effect.getFactorCalculationData().isEmpty()) {
+                try {
                     float factor = this.client.options.getDarknessEffectScale().getValue().floatValue();
-                    float intensity = effect.getFactorCalculationData().get().lerp(e, mc.getLastFrameDuration()) * factor;
-                    float darkness = 1 - (calculateDarknessScale(e, effect.getFactorCalculationData().get().lerp(e, mc.getLastFrameDuration()), mc.getLastFrameDuration()));
+                    float intensity = effect.getFadeFactor(e, mc.getLastFrameDuration()) * factor;
+                    float darkness = 1 - (calculateDarknessScale(e, effect.getFadeFactor(e, mc.getLastFrameDuration()), mc.getLastFrameDuration()));
                     FogLooksGoodNow.LOGGER.info("" + intensity);
                     fogStart = ((8.0F * 16) / renderDistance) * darkness;
                     fogEnd = ((15.0F * 16) / renderDistance);
-                    darknessValue = effect.getFactorCalculationData().get().lerp(e, mc.getLastFrameDuration());
+                    darknessValue = effect.getFadeFactor(e, mc.getLastFrameDuration());
+                } catch (Exception no_status_data_exception) {
+                	
                 }
             }
         }

--- a/src/main/java/com/mineblock11/foglooksgoodnow/config/FLGConfig.java
+++ b/src/main/java/com/mineblock11/foglooksgoodnow/config/FLGConfig.java
@@ -15,7 +15,6 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class FLGConfig {
     private static final YACLHelper.NamespacedHelper HELPER = new YACLHelper.NamespacedHelper("foglooksgoodnow");

--- a/src/main/java/com/mineblock11/foglooksgoodnow/mixin/FogRendererMixin.java
+++ b/src/main/java/com/mineblock11/foglooksgoodnow/mixin/FogRendererMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.client.render.FogShape;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/com/mineblock11/foglooksgoodnow/mixin/LevelRendererMixin.java
+++ b/src/main/java/com/mineblock11/foglooksgoodnow/mixin/LevelRendererMixin.java
@@ -7,7 +7,6 @@ import com.mineblock11.foglooksgoodnow.render.CaveFogRenderer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.WorldRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,11 +27,11 @@ public class LevelRendererMixin {
         FogManager.instance().close();
     }
 
-    @Inject(method = "renderSky(Lnet/minecraft/client/util/math/MatrixStack;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V", at = @At("TAIL"))
-    public void renderSky(MatrixStack poseStack, Matrix4f projectionMatrix, float partialTick, Camera camera, boolean isFoggy, Runnable setupFog, CallbackInfo ci) {
+    @Inject(method = "renderSky(Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V", at = @At("TAIL"))
+    public void renderSky(Matrix4f modelMatrix, Matrix4f projectionMatrix, float partialTick, Camera camera, boolean isFoggy, Runnable setupFog, CallbackInfo ci) {
         if(FLGConfig.get().disableAll) return;
 
         MinecraftClient mc = MinecraftClient.getInstance();
-        CaveFogRenderer.renderCaveFog(mc.world, partialTick, poseStack, camera, projectionMatrix, isFoggy, setupFog);
+        CaveFogRenderer.renderCaveFog(mc.world, partialTick, modelMatrix, camera, projectionMatrix, isFoggy, setupFog);
     }
 }

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,5 +1,5 @@
 plugins.apply 'dev.kikugie.stonecutter'
-stonecutter.active "1.20.4"
+stonecutter.active "1.20.6"
 //-------- !DO NOT EDIT ABOVE THIS LINE! --------\\
 
 stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,0 +1,10 @@
+mod.target=>=1.20.5 <=1.20.6
+
+deps.yarn=1.20.6+build.3
+deps.fabric_api=0.99.4+1.20.6
+deps.yacl_version=3.4.4+1.20.6
+deps.mru_version=0.4.2+1.20.6
+
+runtime.modmenu_version=10.0.0-beta.1
+runtime.sodium_version=mc1.20.6-0.5.8
+runtime.iris_version=1.7.0+1.20.6


### PR DESCRIPTION
I just updated the renderSky Inject to match the now needed variable type Matrix4f instead of MatrixStack, and updated the references in CaveFogRender.java
The math I implemented in CaveFogRender.java to account for the use of Matrix4f was provided by ChatGPT.

In FogManager.java I had to workaround the deletion of the getFactorCalculationData() method and the FactorCalculationData class altogether. This could definitely be improved, I just didn't want to put even more effort into it now.

I hope this can be a nice contribution since many mod developers are refusing to update to 1.20.6, understandably.
I just happened to update my hardcore world to 1.20.6 so here we are now haha